### PR TITLE
Allow exporting subtitles on clip creation

### DIFF
--- a/.lua-format
+++ b/.lua-format
@@ -1,0 +1,1 @@
+column_limit: 120

--- a/clipper/clipper-linux.lua
+++ b/clipper/clipper-linux.lua
@@ -10,7 +10,7 @@ FFMPEG = "ffmpeg"
 FFPROBE = "ffprobe"
 ENCODE_PRESETS = {
     ["Test Encode (fast)"] = {
-        options = "-c:v libx264 -preset ultrafast -tune zerolatency -c:a aac",
+        options = "-c:v libx264 -preset ultrafast -tune zerolatency -s 1280x720 -c:a aac",
         extension = ".mp4"
     },
     ["Twitter Encode (quick and OK quality, MP4)"] = {


### PR DESCRIPTION
This adds two UI elements to allow toggling of hardsubbing video as well as to export a subtitle file with adjusted timestamps (that can be used as CCs for the final clip).

![image](https://user-images.githubusercontent.com/1318013/90717439-35ce8780-e275-11ea-8d29-57d453ba88e4.png)

An example workflow using this would be:
1. Finish subbing a clip with multiple segments, with styles meant to look good on the video.
2. Run Clipper with hardsubbing and exporting enabled (check the box). Since exporting uses the same name as the clip name, ensure you change the clip name to something else to prevent overwriting your working file.
3. Open the exported subtitle file (same name as clip name) and update styles for use on YouTube.
4. Remove any (possibly broken) signs/etc that don't need to be in the CCs, or modify them.
5. Use YTSubConverter to create a .ytt file
6. Upload as CCs to YouTube.

Other changes:
- update test profile to downscale video to 720p (nothing actually checks this but most people will be using 720p or 1080p video anyway)
- lua formatting rule added to extend column width to 120 chars