### PR TITLE
Remove split filter to reduce RAM usage

### DIFF
--- a/clipper/clipper-linux.lua
+++ b/clipper/clipper-linux.lua
@@ -126,13 +126,13 @@ function build_segments(sub, sel, explicit)
             if line_timings[i][1] >= previous_end and line_timings[i][1] - previous_end <= frame_duration then
                 -- merge lines if they're right after one another
                 segments[#segments][2] = line_timings[i][2]
-            elseif line_timings[i][1] > previous_end then
+            elseif line_timings[i][1] > previous_end and line_timings[i][1] - previous_end <= 60000 then
                 -- add a timing within the current segment since it falls after
-                -- earlier defined segments
+                -- earlier defined segments, but within a minute of the next
                 table.insert(segments, {line_timings[i][1], line_timings[i][2]})
             else
-                -- if a line goes backwards, save the current segment input and
-                -- initialize a new list of segments
+                -- if a line goes backwards, or is a minute away, save the
+                -- current segment input and initialize a new list of segments
                 table.insert(segment_inputs, segments)
                 segments = {{line_timings[i][1], line_timings[i][2]}}
             end


### PR DESCRIPTION
How we're using the `split` filter can lead to a lot of RAM usage depending on how segments are defined. This tunes the encoder command to use multiple trimmed inputs from the same file, as well as segments inputs further if the selection has lines that are further than a minute apart (whereas previously we only segmented if they went backwards in time).

In short, these changes reduce out of memory-related crashes and significantly speeds up encodes where one segment is at the very beginning of a stream and another is at the very end.

Also see https://video.stackexchange.com/questions/26132/why-trimming-in-ffmpeg-eats-up-so-much-memory

I also got rid of that old code I used to use in my old workflow, but I guess that code hasn't been reachable for a while now.