### PR TITLE
Use stream v0 when probing for color space

### DIFF
--- a/clipper/clipper-windows.lua
+++ b/clipper/clipper-windows.lua
@@ -290,7 +290,7 @@ end
 function id_colorspace(video)
     local values = {}
 
-    local cmd = ('"%s" -show_streams -select_streams v "%s"'):format(FFPROBE,
+    local cmd = ('"%s" -show_streams -select_streams v:0 "%s"'):format(FFPROBE,
                                                                      video)
 
     local res = run_as_batch(cmd, function(pipe)


### PR DESCRIPTION
When a file contains both a video and a picture, for example when saving thumbnail with ytarchive, the script finds the color space from the thumbnail and applies it to the video. If the picture contains a different color space it will make the final video have bad colors.

Fix will select video stream so it can find the correct color space.


| Original | Without fix | With fix |
|----|----|----|
| ![20220606_Una pequeña charlita_001_252008](https://user-images.githubusercontent.com/5872452/172282831-025b71b2-9a57-4916-93d1-4c786fe5cacb.png) | ![20220606_Una pequeña charlita-2 mp4_00_00_00 000](https://user-images.githubusercontent.com/5872452/172283129-01116995-393e-47ba-9a98-e227e6416c11.jpg) | ![unlimited super chat works mp4_00_00_00 000](https://user-images.githubusercontent.com/5872452/172282792-6e6db6d0-408f-44af-a815-c7b770310e4a.jpg) |
| ![image](https://user-images.githubusercontent.com/5872452/172283232-e75fd264-47e7-45b4-9ec2-ced8b8b892a5.png) | ![image](https://user-images.githubusercontent.com/5872452/172283280-565f78ba-e04c-4478-a7ab-cb65df01515e.png) | ![image](https://user-images.githubusercontent.com/5872452/172283327-3dcadcb2-5c5a-4ce8-b898-79c75e89bdab.png) |